### PR TITLE
add google-oauthlib-tool entry point

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,11 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
+  entry_points:
+    - google-oauthlib-tool = google_auth_oauthlib.tool.__main__:main
 
 requirements:
   build:
@@ -25,10 +27,13 @@ requirements:
     - python
     - google-auth
     - requests-oauthlib >=0.7.0
+    - click
 
 test:
   imports:
     - google_auth_oauthlib
+  commands:
+    - google-oauthlib-tool --help
 
 about:
   home: https://github.com/googleapis/google-auth-library-python-oauthlib


### PR DESCRIPTION
Add the google-oauthlib-tool entry point along with a test.  This tool
requires click at run time.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
